### PR TITLE
Remove ESM flag to avoid module type error

### DIFF
--- a/app.json
+++ b/app.json
@@ -39,7 +39,6 @@
       }
     }
   ],
-  "esm": true,
   "drivers": [
     {
       "name": {


### PR DESCRIPTION
## Summary
- remove `esm` flag from `app.json` so the app uses CommonJS rather than ES modules

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894a6f8f37c83309685b89fa7e0d6c7