### PR TITLE
Add settings page for WiFi Pool credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains a Homey app for reading data from WiFi Pool compatible 
 1. Navigate to the `homey-app` folder.
 2. Install dependencies (none required by default).
 3. Use the [Homey CLI](https://apps.developer.homey.app/the-basics/getting-started) to run or install the app on your Homey.
+4. Open the app's settings in Homey and enter your WiFi Pool account email and password.
 
 ## 📚 Development Notes
 - API helpers live in `lib/wifipool.js`.

--- a/settings/index.html
+++ b/settings/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>WiFi Pool Settings</title>
+    <script src="/homey.js" data-origin="settings"></script>
+  </head>
+  <body>
+    <fieldset class="homey-form-fieldset">
+      <form class="homey-form" id="credentials-form">
+        <div class="homey-form-group">
+          <label class="homey-form-label" for="email">Email</label>
+          <input class="homey-form-input" type="text" id="email" />
+        </div>
+        <div class="homey-form-group">
+          <label class="homey-form-label" for="password">Password</label>
+          <input class="homey-form-input" type="password" id="password" />
+        </div>
+        <button class="homey-button-primary" type="submit">Save</button>
+      </form>
+    </fieldset>
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/settings/index.js
+++ b/settings/index.js
@@ -1,0 +1,28 @@
+function onHomeyReady(Homey) {
+  window.Homey = Homey;
+
+  const emailField = document.getElementById('email');
+  const passwordField = document.getElementById('password');
+  const form = document.getElementById('credentials-form');
+
+  Homey.get('email', (err, value) => {
+    if (!err && value) emailField.value = value;
+  });
+
+  Homey.get('password', (err, value) => {
+    if (!err && value) passwordField.value = value;
+  });
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    Homey.set('email', emailField.value, (err) => {
+      if (err) return Homey.alert(err.message || err.toString());
+      Homey.set('password', passwordField.value, (err2) => {
+        if (err2) return Homey.alert(err2.message || err2.toString());
+        Homey.alert('Settings saved');
+      });
+    });
+  });
+
+  Homey.ready();
+}


### PR DESCRIPTION
## Summary
- add settings UI for WiFi Pool email and password
- document configuring credentials

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894a8c690e48330a439c5feb947ecc2