### PR TITLE
Log WiFi Pool API calls and enable pairing

### DIFF
--- a/drivers/wifipool/driver.compose.json
+++ b/drivers/wifipool/driver.compose.json
@@ -2,6 +2,7 @@
   "name": { "en": "WiFi Pool" },
   "class": "sensor",
   "capabilities": ["measure_ph", "measure_water.flow", "measure_redox"],
+  "pair": "list_devices",
   "settings": [
     {
       "id": "domain",

--- a/drivers/wifipool/driver.js
+++ b/drivers/wifipool/driver.js
@@ -22,4 +22,13 @@ module.exports = class WiFiPoolDriver extends Driver {
       this.error('WiFi Pool login failed', err);
     }
   }
+
+  async onPairListDevices() {
+    return [
+      {
+        name: 'WiFi Pool',
+        data: { id: 'wifipool' }
+      }
+    ];
+  }
 };

--- a/drivers/wifipool/driver.json
+++ b/drivers/wifipool/driver.json
@@ -2,6 +2,7 @@
   "name": { "en": "WiFi Pool" },
   "class": "sensor",
   "capabilities": ["measure_ph", "measure_water.flow", "measure_redox"],
+  "pair": "list_devices",
   "settings": [
     {
       "id": "domain",

--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -7,11 +7,15 @@ async function login(email, password) {
   const url = 'https://api.wifipool.eu/native_mobile/users/login';
   const loginData = { email, namespace: 'default', password };
 
+  console.log('WiFi Pool API login request', { url, email });
+
   const response = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(loginData)
   });
+
+  console.log('WiFi Pool API login response', { status: response.status });
 
   if (!response.ok) {
     throw new Error(`Login failed: ${response.status}`);
@@ -31,6 +35,8 @@ async function getStats(domain, io, cookies = authCookies) {
   const url = 'https://api.wifipool.eu/native_mobile/harmopool/getStats';
   const data = { after: 1723973699831, domain, io };
 
+  console.log('WiFi Pool API stats request', { url, domain, io });
+
   const response = await fetch(url, {
     method: 'POST',
     headers: {
@@ -40,11 +46,15 @@ async function getStats(domain, io, cookies = authCookies) {
     body: JSON.stringify(data)
   });
 
+  console.log('WiFi Pool API stats response', { status: response.status });
+
   if (!response.ok) {
     throw new Error(`Data request failed: ${response.status}`);
   }
 
-  return await response.json();
+  const json = await response.json();
+  console.log('WiFi Pool API stats data', json);
+  return json;
 }
 
 // Extract laatste waarde voor een key uit sensor data


### PR DESCRIPTION
## Summary
- add console logging for WiFi Pool API login and stats requests
- enable pairing by listing WiFi Pool device during device discovery

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894abfdb30c8330900836f587828a18