### PR TITLE
Add pairing view for WiFi Pool driver

### DIFF
--- a/drivers/wifipool/driver.json
+++ b/drivers/wifipool/driver.json
@@ -2,7 +2,18 @@
   "name": { "en": "WiFi Pool" },
   "class": "sensor",
   "capabilities": ["measure_ph", "measure_water_flow", "measure_redox"],
-  "pair": "list_devices",
+  "pair": [
+    {
+      "id": "view",
+      "template": "view.html",
+      "navigation": {
+        "next": "list_devices"
+      }
+    },
+    {
+      "id": "list_devices"
+    }
+  ],
   "settings": [
     {
       "id": "domain",

--- a/drivers/wifipool/pair/view.html
+++ b/drivers/wifipool/pair/view.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Pair WiFi Pool</title>
+  </head>
+  <body>
+    <p>Start pairing your WiFi Pool device.</p>
+    <button id="next">Next</button>
+    <script src="view.js"></script>
+  </body>
+</html>

--- a/drivers/wifipool/pair/view.js
+++ b/drivers/wifipool/pair/view.js
@@ -1,0 +1,6 @@
+Homey.on('init', () => {
+  const nextBtn = document.getElementById('next');
+  nextBtn.addEventListener('click', () => {
+    Homey.showView('list_devices');
+  });
+});


### PR DESCRIPTION
## Summary
- add basic pairing instructions for WiFi Pool device
- allow navigating to Homey's built-in device list during pairing

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894bf54434c833098360a9dd6492245