### PR TITLE
Add list device view and fix WiFiPoolDevice export

### DIFF
--- a/drivers/wifipool/device.js
+++ b/drivers/wifipool/device.js
@@ -55,4 +55,4 @@ class WiFiPoolDevice extends Device {
   }
 };
 
-module.exports = WifiPoolDevice;
+module.exports = WiFiPoolDevice;

--- a/drivers/wifipool/driver.compose.json
+++ b/drivers/wifipool/driver.compose.json
@@ -24,7 +24,8 @@
       }
     },
     {
-      "id": "list_devices"
+      "id": "list_devices",
+      "template": "list_devices.html"
     }
   ],
 

--- a/drivers/wifipool/pair/list_devices.html
+++ b/drivers/wifipool/pair/list_devices.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Select WiFi Pool Device</title>
+  </head>
+  <body>
+    <p>Selecteer het WiFi Pool apparaat om toe te voegen:</p>
+    <ul id="devices"></ul>
+    <script src="list_devices.js"></script>
+  </body>
+</html>

--- a/drivers/wifipool/pair/list_devices.js
+++ b/drivers/wifipool/pair/list_devices.js
@@ -1,0 +1,23 @@
+Homey.on('init', () => {
+  Homey.emit('list_devices', {}, (err, devices) => {
+    if (err) {
+      return Homey.alert(err);
+    }
+
+    const list = document.getElementById('devices');
+    devices.forEach(device => {
+      const li = document.createElement('li');
+      const btn = document.createElement('button');
+      btn.textContent = device.name;
+      btn.addEventListener('click', () => {
+        Homey.createDevice(device, (createErr) => {
+          if (createErr) {
+            return Homey.alert(createErr);
+          }
+        });
+      });
+      li.appendChild(btn);
+      list.appendChild(li);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add pairing view for listing WiFi Pool devices
- fix WiFiPoolDevice export name
- link pair step to list_devices template

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895b44c023c8330bb0a06fe16608df8