### PR TITLE
chore: add pairing debug logs

### DIFF
--- a/drivers/wifipool/driver.js
+++ b/drivers/wifipool/driver.js
@@ -24,13 +24,23 @@ class WiFiPoolDriver extends Driver {
   }
 
   async onPairListDevices() {
-    return [
-      {
-        name: 'WiFi Pool Sensor',
-        data: { id: 'wifipool-1' }, // unieke ID binnen jouw app
-        settings: { domain: '', io: 0 },
-      },
-    ];
+    this.log('Pairing: listing available devices');
+
+    try {
+      const devices = [
+        {
+          name: 'WiFi Pool Sensor',
+          data: { id: 'wifipool-1' }, // unieke ID binnen jouw app
+          settings: { domain: '', io: 0 },
+        },
+      ];
+
+      this.log('Pairing: found', devices.length, 'device(s)');
+      return devices;
+    } catch (err) {
+      this.error('Pairing: failed to list devices', err);
+      throw err;
+    }
   }
 }
 

--- a/drivers/wifipool/pair/list_devices.js
+++ b/drivers/wifipool/pair/list_devices.js
@@ -1,19 +1,26 @@
 Homey.on('init', () => {
+  console.log('Pairing: view initialized, requesting device list');
   Homey.emit('list_devices', {}, (err, devices) => {
     if (err) {
+      console.error('Pairing: error retrieving devices', err);
       return Homey.alert(err);
     }
 
+    console.log('Pairing: received devices', devices);
     const list = document.getElementById('devices');
     devices.forEach(device => {
       const li = document.createElement('li');
       const btn = document.createElement('button');
       btn.textContent = device.name;
       btn.addEventListener('click', () => {
+        console.log('Pairing: creating device', device);
         Homey.createDevice(device, (createErr) => {
           if (createErr) {
+            console.error('Pairing: error creating device', createErr);
             return Homey.alert(createErr);
           }
+
+          console.log('Pairing: device created successfully');
         });
       });
       li.appendChild(btn);

--- a/drivers/wifipool/pair/view.js
+++ b/drivers/wifipool/pair/view.js
@@ -1,6 +1,8 @@
 Homey.on('init', () => {
+  console.log('Pairing: start view initialized');
   const nextBtn = document.getElementById('next');
   nextBtn.addEventListener('click', () => {
+    console.log('Pairing: next button clicked, showing device list');
     Homey.showView('list_devices');
   });
 });


### PR DESCRIPTION
## Summary
- log pair flow on driver and frontend
- log errors when device creation fails

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895b948b42483308780f140207a110d