### PR TITLE
Display live logs on pairing screens

### DIFF
--- a/drivers/wifipool/pair/list_devices.html
+++ b/drivers/wifipool/pair/list_devices.html
@@ -7,6 +7,7 @@
   <body>
     <p>Selecteer het WiFi Pool apparaat om toe te voegen:</p>
     <ul id="devices"></ul>
+    <pre id="log"></pre>
     <script src="list_devices.js"></script>
   </body>
 </html>

--- a/drivers/wifipool/pair/list_devices.js
+++ b/drivers/wifipool/pair/list_devices.js
@@ -1,26 +1,37 @@
+function publishLog(...args) {
+  console.log(...args);
+  const logEl = document.getElementById('log');
+  if (logEl) {
+    const msg = args
+      .map(a => (typeof a === 'object' ? JSON.stringify(a) : String(a)))
+      .join(' ');
+    logEl.textContent += `${msg}\n`;
+  }
+}
+
 Homey.on('init', () => {
-  console.log('Pairing: view initialized, requesting device list');
+  publishLog('Pairing: view initialized, requesting device list');
   Homey.emit('list_devices', {}, (err, devices) => {
     if (err) {
-      console.error('Pairing: error retrieving devices', err);
+      publishLog('Pairing: error retrieving devices', err);
       return Homey.alert(err);
     }
 
-    console.log('Pairing: received devices', devices);
+    publishLog('Pairing: received devices', devices);
     const list = document.getElementById('devices');
     devices.forEach(device => {
       const li = document.createElement('li');
       const btn = document.createElement('button');
       btn.textContent = device.name;
       btn.addEventListener('click', () => {
-        console.log('Pairing: creating device', device);
+        publishLog('Pairing: creating device', device);
         Homey.createDevice(device, (createErr) => {
           if (createErr) {
-            console.error('Pairing: error creating device', createErr);
+            publishLog('Pairing: error creating device', createErr);
             return Homey.alert(createErr);
           }
 
-          console.log('Pairing: device created successfully');
+          publishLog('Pairing: device created successfully');
         });
       });
       li.appendChild(btn);

--- a/drivers/wifipool/pair/view.html
+++ b/drivers/wifipool/pair/view.html
@@ -7,6 +7,7 @@
   <body>
     <p>Start pairing your WiFi Pool device.</p>
     <button id="next">Next</button>
+    <pre id="log"></pre>
     <script src="view.js"></script>
   </body>
 </html>

--- a/drivers/wifipool/pair/view.js
+++ b/drivers/wifipool/pair/view.js
@@ -1,8 +1,19 @@
+function publishLog(...args) {
+  console.log(...args);
+  const logEl = document.getElementById('log');
+  if (logEl) {
+    const msg = args
+      .map(a => (typeof a === 'object' ? JSON.stringify(a) : String(a)))
+      .join(' ');
+    logEl.textContent += `${msg}\n`;
+  }
+}
+
 Homey.on('init', () => {
-  console.log('Pairing: start view initialized');
+  publishLog('Pairing: start view initialized');
   const nextBtn = document.getElementById('next');
   nextBtn.addEventListener('click', () => {
-    console.log('Pairing: next button clicked, showing device list');
+    publishLog('Pairing: next button clicked, showing device list');
     Homey.showView('list_devices');
   });
 });


### PR DESCRIPTION
## Summary
- show real-time log output on initial pairing view
- show real-time log output on device selection view

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895bab938248330910fed47cc716584