### PR TITLE
Log available devices after driver login

### DIFF
--- a/drivers/wifipool/driver.js
+++ b/drivers/wifipool/driver.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Driver } = require('homey');
-const { login } = require('../../lib/wifipool.js');
+const { login, getDevices } = require('../../lib/wifipool.js');
 
 class WiFiPoolDriver extends Driver {
   async onInit() {
@@ -18,6 +18,13 @@ class WiFiPoolDriver extends Driver {
     try {
       await login(email, password);
       this.log('WiFi Pool login successful');
+
+      try {
+        const devices = await getDevices();
+        this.log('WiFi Pool available devices', devices);
+      } catch (err) {
+        this.error('Failed to fetch WiFi Pool devices', err);
+      }
     } catch (err) {
       this.error('WiFi Pool login failed', err);
     }

--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -57,6 +57,32 @@ async function getStats(domain, io, cookies = authCookies) {
   return json;
 }
 
+// Vraag lijst met beschikbare devices op
+async function getDevices(cookies = authCookies) {
+  const url = 'https://api.wifipool.eu/native_mobile/harmopool/getDevices';
+
+  console.log('WiFi Pool API devices request', { url });
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Cookie': cookies
+    },
+    body: JSON.stringify({})
+  });
+
+  console.log('WiFi Pool API devices response', { status: response.status });
+
+  if (!response.ok) {
+    throw new Error(`Device request failed: ${response.status}`);
+  }
+
+  const json = await response.json();
+  console.log('WiFi Pool API devices data', json);
+  return json;
+}
+
 // Extract laatste waarde voor een key uit sensor data
 function extractLatestValue(data, key) {
   if (Array.isArray(data) && data.length > 0) {
@@ -74,5 +100,6 @@ module.exports = {
   login,
   getCookies,
   getStats,
+  getDevices,
   extractLatestValue
 };


### PR DESCRIPTION
## Summary
- log available WiFi Pool devices during driver init
- add API helper to fetch devices

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895bca5c5008330b6245ad26733c972