### PR TITLE
fix: update WiFi Pool devices API path

### DIFF
--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -59,7 +59,7 @@ async function getStats(domain, io, cookies = authCookies) {
 
 // Vraag lijst met beschikbare devices op
 async function getDevices(cookies = authCookies) {
-  const url = 'https://api.wifipool.eu/native_mobile/harmopool/getDevices';
+  const url = 'https://api.wifipool.eu/native_mobile/harmopool/getDevice';
 
   console.log('WiFi Pool API devices request', { url });
 


### PR DESCRIPTION
## Summary
- point WiFi Pool device fetch to new `getDevice` endpoint

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895be288c04833088b63e6b395d2ced