### PR TITLE
Handle domain for WiFi Pool device lookup

### DIFF
--- a/drivers/wifipool/driver.js
+++ b/drivers/wifipool/driver.js
@@ -16,11 +16,11 @@ class WiFiPoolDriver extends Driver {
     }
 
     try {
-      await login(email, password);
+      const { domain } = await login(email, password);
       this.log('WiFi Pool login successful');
 
       try {
-        const devices = await getDevices();
+        const devices = await getDevices(domain);
         this.log('WiFi Pool available devices', devices);
       } catch (err) {
         this.error('Failed to fetch WiFi Pool devices', err);

--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -1,8 +1,9 @@
 const fetch = require('node-fetch');
 
 let authCookies = '';
+let userDomain = '';
 
-// Login bij WiFi Pool API en sla cookies op
+// Login bij WiFi Pool API en sla cookies en relevante info op
 async function login(email, password) {
   const url = 'https://api.wifipool.eu/native_mobile/users/login';
   const loginData = { email, namespace: 'default', password };
@@ -22,12 +23,27 @@ async function login(email, password) {
   }
 
   authCookies = response.headers.get('set-cookie') || '';
-  return { cookies: authCookies };
+
+  // Probeer het domein uit de login response op te slaan
+  try {
+    const body = await response.json();
+    userDomain = body?.user?.domain || '';
+  } catch (err) {
+    // Als het parsen mislukt, is het niet fataal
+    userDomain = '';
+  }
+
+  return { cookies: authCookies, domain: userDomain };
 }
 
 // Haal de opgeslagen cookies op
 function getCookies() {
   return authCookies;
+}
+
+// Haal het gedetecteerde domein op
+function getDomain() {
+  return userDomain;
 }
 
 // Vraag actuele statistieken op
@@ -58,10 +74,12 @@ async function getStats(domain, io, cookies = authCookies) {
 }
 
 // Vraag lijst met beschikbare devices op
-async function getDevices(cookies = authCookies) {
+async function getDevices(domain = userDomain, cookies = authCookies) {
   const url = 'https://api.wifipool.eu/native_mobile/harmopool/getDevice';
 
-  console.log('WiFi Pool API devices request', { url });
+  console.log('WiFi Pool API devices request', { url, domain });
+
+  const body = domain ? { domain } : {};
 
   const response = await fetch(url, {
     method: 'POST',
@@ -69,7 +87,7 @@ async function getDevices(cookies = authCookies) {
       'Content-Type': 'application/json',
       'Cookie': cookies
     },
-    body: JSON.stringify({})
+    body: JSON.stringify(body)
   });
 
   console.log('WiFi Pool API devices response', { status: response.status });
@@ -99,6 +117,7 @@ function extractLatestValue(data, key) {
 module.exports = {
   login,
   getCookies,
+  getDomain,
   getStats,
   getDevices,
   extractLatestValue


### PR DESCRIPTION
## Summary
- store domain from WiFi Pool login and expose it
- include domain in device list requests to avoid 400 errors
- pass returned domain to device lookup during driver init

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6895c1d80ab483308eb1ae2da32063cf