### PR TITLE
Fix WiFi Pool Homey integration using Home Assistant logic

### DIFF
--- a/drivers/wifipool/device.js
+++ b/drivers/wifipool/device.js
@@ -2,57 +2,77 @@
 
 const { Device } = require('homey');
 const {
+  login,
   getStats,
-  extractLatestValue,
-  getCookies
+  extractAnalog,
+  extractSwitch,
 } = require('../../lib/wifipool.js');
 
-const CAPABILITIES = [
-  { id: 'measure_ph', key: '4' },
-  { id: 'measure_water_flow', key: '5' },
-  { id: 'measure_redox', key: '6' }
-];
+// IO identifiers taken from the Home Assistant integration
+const IO_PH = 'e61d476d-bbd0-4527-a9f5-ef0170caa33c.o3';
+const IO_FLOW = 'e61d476d-bbd0-4527-a9f5-ef0170caa33c.o0';
+const IO_REDOX = 'e61d476d-bbd0-4527-a9f5-ef0170caa33c.o4';
 
 class WiFiPoolDevice extends Device {
   async onInit() {
     this.log('WiFi Pool device initialized');
 
-    // Voeg capabilities toe als ze nog niet aanwezig zijn
-    for (const { id } of CAPABILITIES) {
+    const capabilities = ['measure_ph', 'measure_water_flow', 'measure_redox'];
+    for (const id of capabilities) {
       if (!this.hasCapability(id)) {
         await this.addCapability(id);
       }
     }
 
-    // Initiele sensorupdate
     await this.updateSensors();
-
-    // Herhaal elke 60 seconden
     this.setInterval(() => this.updateSensors(), 60 * 1000);
   }
 
   async updateSensors() {
-    const { domain, io } = this.getSettings();
-    const cookies = getCookies();
+    const email = this.homey.settings.get('email');
+    const password = this.homey.settings.get('password');
 
-    if (!cookies) {
-      this.error('No WiFi Pool authentication cookies available');
+    if (!email || !password) {
+      this.error('WiFi Pool credentials missing. Please configure them in the app settings.');
       return;
     }
 
     try {
-      const data = await getStats(domain, io, cookies);
+      const { cookies, domain: loginDomain } = await login(email, password);
+      const domain = this.getSettings().domain || loginDomain;
 
-      for (const { id, key } of CAPABILITIES) {
-        const value = extractLatestValue(data, key);
-        if (value !== null) {
-          await this.setCapabilityValue(id, value);
-        }
-      }
+      await this.updatePh(domain, cookies);
+      await this.updateFlow(domain, cookies);
+      await this.updateRedox(domain, cookies);
     } catch (err) {
       this.error('Failed to update sensors:', err.message || err);
     }
   }
-};
+
+  async updatePh(domain, cookies) {
+    const data = await getStats(domain, IO_PH, cookies);
+    const value = extractAnalog(data, '4');
+    if (value !== null) {
+      await this.setCapabilityValue('measure_ph', value);
+    }
+  }
+
+  async updateFlow(domain, cookies) {
+    const data = await getStats(domain, IO_FLOW, cookies);
+    const value = extractSwitch(data, '1');
+    if (value !== null) {
+      await this.setCapabilityValue('measure_water_flow', value);
+    }
+  }
+
+  async updateRedox(domain, cookies) {
+    const data = await getStats(domain, IO_REDOX, cookies);
+    const value = extractAnalog(data, '1');
+    if (value !== null) {
+      await this.setCapabilityValue('measure_redox', value);
+    }
+  }
+}
 
 module.exports = WiFiPoolDevice;
+

--- a/drivers/wifipool/driver.compose.json
+++ b/drivers/wifipool/driver.compose.json
@@ -39,16 +39,6 @@
       "hint": {
         "en": "IP or hostname of the pool system"
       }
-    },
-    {
-      "id": "io",
-      "type": "number",
-      "label": {
-        "en": "IO Channel"
-      },
-      "hint": {
-        "en": "The IO index for this sensor"
-      }
     }
   ],
   "images": {

--- a/drivers/wifipool/driver.js
+++ b/drivers/wifipool/driver.js
@@ -1,47 +1,32 @@
 'use strict';
 
 const { Driver } = require('homey');
-const { login, getDevices } = require('../../lib/wifipool.js');
+const { login } = require('../../lib/wifipool.js');
 
 class WiFiPoolDriver extends Driver {
   async onInit() {
     this.log('WiFi Pool driver initialized');
-
-    const email = this.homey.settings.get('email');
-    const password = this.homey.settings.get('password');
-
-    if (!email || !password) {
-      this.error('WiFi Pool credentials missing. Please configure email and password in the app settings.');
-      return;
-    }
-
-    try {
-      const { domain } = await login(email, password);
-      this.log('WiFi Pool login successful');
-
-      try {
-        const devices = await getDevices(domain);
-        this.log('WiFi Pool available devices', devices);
-      } catch (err) {
-        this.error('Failed to fetch WiFi Pool devices', err);
-      }
-    } catch (err) {
-      this.error('WiFi Pool login failed', err);
-    }
   }
 
   async onPairListDevices() {
     this.log('Pairing: listing available devices');
 
+    const email = this.homey.settings.get('email');
+    const password = this.homey.settings.get('password');
+
+    if (!email || !password) {
+      throw new Error('Configure email and password in the app settings.');
+    }
+
     try {
+      const { domain } = await login(email, password);
       const devices = [
         {
           name: 'WiFi Pool Sensor',
-          data: { id: 'wifipool-1' }, // unieke ID binnen jouw app
-          settings: { domain: '', io: 0 },
+          data: { id: 'wifipool-1' },
+          settings: { domain },
         },
       ];
-
       this.log('Pairing: found', devices.length, 'device(s)');
       return devices;
     } catch (err) {

--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -49,7 +49,7 @@ function getDomain() {
 // Vraag actuele statistieken op
 async function getStats(domain, io, cookies = authCookies) {
   const url = 'https://api.wifipool.eu/native_mobile/harmopool/getStats';
-  const data = { after: 1723973699831, domain, io };
+  const data = { after: 0, domain, io };
 
   console.log('WiFi Pool API stats request', { url, domain, io });
 
@@ -101,13 +101,25 @@ async function getDevices(domain = userDomain, cookies = authCookies) {
   return json;
 }
 
-// Extract laatste waarde voor een key uit sensor data
-function extractLatestValue(data, key) {
+// Extract laatste waarde voor een key uit "analog" sensor data
+function extractAnalog(data, key) {
   if (Array.isArray(data) && data.length > 0) {
     const latestEntry = data[data.length - 1];
     const analog = latestEntry?.device_sensor_data?.analog;
     if (analog && analog[key] !== undefined) {
       return analog[key];
+    }
+  }
+  return null;
+}
+
+// Extract laatste waarde voor een key uit "switch" sensor data
+function extractSwitch(data, key) {
+  if (Array.isArray(data) && data.length > 0) {
+    const latestEntry = data[data.length - 1];
+    const sw = latestEntry?.device_sensor_data?.switch;
+    if (sw && sw[key] !== undefined) {
+      return sw[key];
     }
   }
   return null;
@@ -120,5 +132,6 @@ module.exports = {
   getDomain,
   getStats,
   getDevices,
-  extractLatestValue
+  extractAnalog,
+  extractSwitch
 };


### PR DESCRIPTION
## Summary
- refactor device to fetch pH, flow and redox data using fixed IO identifiers
- simplify driver pairing and remove unused IO setting
- expose helpers for analog and switch values from WiFi Pool API

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895c3cbecf88330822a9f54f87fe580