### PR TITLE
Log WiFi Pool API requests and values

### DIFF
--- a/drivers/wifipool/device.js
+++ b/drivers/wifipool/device.js
@@ -53,6 +53,7 @@ class WiFiPoolDevice extends Device {
     const data = await getStats(domain, IO_PH, cookies);
     const value = extractAnalog(data, '4');
     if (value !== null) {
+      this.log('Received pH value', value);
       await this.setCapabilityValue('measure_ph', value);
     }
   }
@@ -61,6 +62,7 @@ class WiFiPoolDevice extends Device {
     const data = await getStats(domain, IO_FLOW, cookies);
     const value = extractSwitch(data, '1');
     if (value !== null) {
+      this.log('Received flow value', value);
       await this.setCapabilityValue('measure_water_flow', value);
     }
   }
@@ -69,6 +71,7 @@ class WiFiPoolDevice extends Device {
     const data = await getStats(domain, IO_REDOX, cookies);
     const value = extractAnalog(data, '1');
     if (value !== null) {
+      this.log('Received redox value', value);
       await this.setCapabilityValue('measure_redox', value);
     }
   }

--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -7,8 +7,9 @@ let userDomain = '';
 async function login(email, password) {
   const url = 'https://api.wifipool.eu/native_mobile/users/login';
   const loginData = { email, namespace: 'default', password };
+  const safeLoginData = { ...loginData, password: '***' };
 
-  console.log('WiFi Pool API login request', { url, email });
+  console.log('WiFi Pool API login request', { url, body: safeLoginData });
 
   const response = await fetch(url, {
     method: 'POST',
@@ -27,6 +28,7 @@ async function login(email, password) {
   // Probeer het domein uit de login response op te slaan
   try {
     const body = await response.json();
+    console.log('WiFi Pool API login data', body);
     userDomain = body?.user?.domain || '';
   } catch (err) {
     // Als het parsen mislukt, is het niet fataal
@@ -52,6 +54,7 @@ async function getStats(domain, io, cookies = authCookies) {
   const data = { after: 0, domain, io };
 
   console.log('WiFi Pool API stats request', { url, domain, io });
+  console.log('WiFi Pool API stats payload', data);
 
   const response = await fetch(url, {
     method: 'POST',
@@ -80,6 +83,7 @@ async function getDevices(domain = userDomain, cookies = authCookies) {
   console.log('WiFi Pool API devices request', { url, domain });
 
   const body = domain ? { domain } : {};
+  console.log('WiFi Pool API devices payload', body);
 
   const response = await fetch(url, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- log payloads and responses for WiFi Pool API requests
- log sensor values received from the API before updating capabilities

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check lib/wifipool.js drivers/wifipool/device.js`


------
https://chatgpt.com/codex/tasks/task_e_6895c7089ba8833086757c0bbc255573