### PR TITLE
Log available sensor data after API login

### DIFF
--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -35,6 +35,13 @@ async function login(email, password) {
     userDomain = '';
   }
 
+  // Na een succesvolle login: haal alle beschikbare sensorgegevens op
+  try {
+    await logAvailableSensors(userDomain, authCookies);
+  } catch (err) {
+    console.log('WiFi Pool API sensor retrieval failed', err.message || err);
+  }
+
   return { cookies: authCookies, domain: userDomain };
 }
 
@@ -103,6 +110,39 @@ async function getDevices(domain = userDomain, cookies = authCookies) {
   const json = await response.json();
   console.log('WiFi Pool API devices data', json);
   return json;
+}
+
+// Probeer alle sensorgegevens voor de gebruiker op te halen en loggen
+async function logAvailableSensors(domain, cookies) {
+  try {
+    const devicesData = await getDevices(domain, cookies);
+    const devices = Array.isArray(devicesData)
+      ? devicesData
+      : devicesData?.devices;
+
+    if (Array.isArray(devices)) {
+      for (const device of devices) {
+        const rawIo = device?.io_list || device?.io;
+        const ioArray = Array.isArray(rawIo)
+          ? rawIo
+          : rawIo
+            ? [rawIo]
+            : [];
+
+        for (const io of ioArray) {
+          if (!io) continue;
+          try {
+            const stats = await getStats(domain, io, cookies);
+            console.log('WiFi Pool API sensor data', { io, stats });
+          } catch (err) {
+            console.log('WiFi Pool API sensor error', { io, error: err.message || err });
+          }
+        }
+      }
+    }
+  } catch (err) {
+    console.log('WiFi Pool API devices retrieval failed', err.message || err);
+  }
 }
 
 // Extract laatste waarde voor een key uit "analog" sensor data


### PR DESCRIPTION
## Summary
- retrieve and log all available sensor data after a successful API login
- add helper to list devices and request stats for each IO

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895c97d750c83308c86017c585dd184