### PR TITLE
Allow overriding WiFi Pool API IP

### DIFF
--- a/drivers/wifipool/device.js
+++ b/drivers/wifipool/device.js
@@ -31,6 +31,7 @@ class WiFiPoolDevice extends Device {
   async updateSensors() {
     const email = this.homey.settings.get('email');
     const password = this.homey.settings.get('password');
+    const ip = this.homey.settings.get('api_ip');
 
     if (!email || !password) {
       this.error('WiFi Pool credentials missing. Please configure them in the app settings.');
@@ -38,19 +39,19 @@ class WiFiPoolDevice extends Device {
     }
 
     try {
-      const { cookies, domain: loginDomain } = await login(email, password);
+      const { cookies, domain: loginDomain } = await login(email, password, ip);
       const domain = this.getSettings().domain || loginDomain;
 
-      await this.updatePh(domain, cookies);
-      await this.updateFlow(domain, cookies);
-      await this.updateRedox(domain, cookies);
+      await this.updatePh(domain, cookies, ip);
+      await this.updateFlow(domain, cookies, ip);
+      await this.updateRedox(domain, cookies, ip);
     } catch (err) {
       this.error('Failed to update sensors:', err.message || err);
     }
   }
 
-  async updatePh(domain, cookies) {
-    const data = await getStats(domain, IO_PH, cookies);
+  async updatePh(domain, cookies, ip) {
+    const data = await getStats(domain, IO_PH, cookies, ip);
     const value = extractAnalog(data, '4');
     if (value !== null) {
       this.log('Received pH value', value);
@@ -58,8 +59,8 @@ class WiFiPoolDevice extends Device {
     }
   }
 
-  async updateFlow(domain, cookies) {
-    const data = await getStats(domain, IO_FLOW, cookies);
+  async updateFlow(domain, cookies, ip) {
+    const data = await getStats(domain, IO_FLOW, cookies, ip);
     const value = extractSwitch(data, '1');
     if (value !== null) {
       this.log('Received flow value', value);
@@ -67,8 +68,8 @@ class WiFiPoolDevice extends Device {
     }
   }
 
-  async updateRedox(domain, cookies) {
-    const data = await getStats(domain, IO_REDOX, cookies);
+  async updateRedox(domain, cookies, ip) {
+    const data = await getStats(domain, IO_REDOX, cookies, ip);
     const value = extractAnalog(data, '1');
     if (value !== null) {
       this.log('Received redox value', value);

--- a/drivers/wifipool/driver.js
+++ b/drivers/wifipool/driver.js
@@ -13,13 +13,14 @@ class WiFiPoolDriver extends Driver {
 
     const email = this.homey.settings.get('email');
     const password = this.homey.settings.get('password');
+    const ip = this.homey.settings.get('api_ip');
 
     if (!email || !password) {
       throw new Error('Configure email and password in the app settings.');
     }
 
     try {
-      const { domain } = await login(email, password);
+      const { domain } = await login(email, password, ip);
       const devices = [
         {
           name: 'WiFi Pool Sensor',

--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -1,21 +1,34 @@
 const fetch = require('node-fetch');
+const https = require('https');
+
+const API_HOST = 'api.wifipool.eu';
+const API_BASE_URL = `https://${API_HOST}`;
+
+async function apiFetch(path, options = {}, ip) {
+  if (ip) {
+    const agent = new https.Agent({ servername: API_HOST });
+    const headers = { ...(options.headers || {}), Host: API_HOST };
+    return fetch(`https://${ip}${path}`, { ...options, headers, agent });
+  }
+  return fetch(`${API_BASE_URL}${path}`, options);
+}
 
 let authCookies = '';
 let userDomain = '';
 
 // Login bij WiFi Pool API en sla cookies en relevante info op
-async function login(email, password) {
-  const url = 'https://api.wifipool.eu/native_mobile/users/login';
+async function login(email, password, ip) {
+  const path = '/native_mobile/users/login';
   const loginData = { email, namespace: 'default', password };
   const safeLoginData = { ...loginData, password: '***' };
 
-  console.log('WiFi Pool API login request', { url, body: safeLoginData });
+  console.log('WiFi Pool API login request', { path, body: safeLoginData });
 
-  const response = await fetch(url, {
+  const response = await apiFetch(path, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(loginData)
-  });
+    body: JSON.stringify(loginData),
+  }, ip);
 
   console.log('WiFi Pool API login response', { status: response.status });
 
@@ -37,7 +50,7 @@ async function login(email, password) {
 
   // Na een succesvolle login: haal alle beschikbare sensorgegevens op
   try {
-    await logAvailableSensors(userDomain, authCookies);
+    await logAvailableSensors(userDomain, authCookies, ip);
   } catch (err) {
     console.log('WiFi Pool API sensor retrieval failed', err.message || err);
   }
@@ -56,21 +69,21 @@ function getDomain() {
 }
 
 // Vraag actuele statistieken op
-async function getStats(domain, io, cookies = authCookies) {
-  const url = 'https://api.wifipool.eu/native_mobile/harmopool/getStats';
+async function getStats(domain, io, cookies = authCookies, ip) {
+  const path = '/native_mobile/harmopool/getStats';
   const data = { after: 0, domain, io };
 
-  console.log('WiFi Pool API stats request', { url, domain, io });
+  console.log('WiFi Pool API stats request', { path, domain, io });
   console.log('WiFi Pool API stats payload', data);
 
-  const response = await fetch(url, {
+  const response = await apiFetch(path, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Cookie': cookies
     },
-    body: JSON.stringify(data)
-  });
+    body: JSON.stringify(data),
+  }, ip);
 
   console.log('WiFi Pool API stats response', { status: response.status });
 
@@ -84,22 +97,22 @@ async function getStats(domain, io, cookies = authCookies) {
 }
 
 // Vraag lijst met beschikbare devices op
-async function getDevices(domain = userDomain, cookies = authCookies) {
-  const url = 'https://api.wifipool.eu/native_mobile/harmopool/getDevice';
+async function getDevices(domain = userDomain, cookies = authCookies, ip) {
+  const path = '/native_mobile/harmopool/getDevice';
 
-  console.log('WiFi Pool API devices request', { url, domain });
+  console.log('WiFi Pool API devices request', { path, domain });
 
   const body = domain ? { domain } : {};
   console.log('WiFi Pool API devices payload', body);
 
-  const response = await fetch(url, {
+  const response = await apiFetch(path, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Cookie': cookies
     },
-    body: JSON.stringify(body)
-  });
+    body: JSON.stringify(body),
+  }, ip);
 
   console.log('WiFi Pool API devices response', { status: response.status });
 
@@ -113,9 +126,9 @@ async function getDevices(domain = userDomain, cookies = authCookies) {
 }
 
 // Probeer alle sensorgegevens voor de gebruiker op te halen en loggen
-async function logAvailableSensors(domain, cookies) {
+async function logAvailableSensors(domain, cookies, ip) {
   try {
-    const devicesData = await getDevices(domain, cookies);
+    const devicesData = await getDevices(domain, cookies, ip);
     const devices = Array.isArray(devicesData)
       ? devicesData
       : devicesData?.devices;
@@ -132,7 +145,7 @@ async function logAvailableSensors(domain, cookies) {
         for (const io of ioArray) {
           if (!io) continue;
           try {
-            const stats = await getStats(domain, io, cookies);
+            const stats = await getStats(domain, io, cookies, ip);
             console.log('WiFi Pool API sensor data', { io, stats });
           } catch (err) {
             console.log('WiFi Pool API sensor error', { io, error: err.message || err });

--- a/settings/index.html
+++ b/settings/index.html
@@ -16,6 +16,10 @@
           <label class="homey-form-label" for="password">Password</label>
           <input class="homey-form-input" type="password" id="password" />
         </div>
+        <div class="homey-form-group">
+          <label class="homey-form-label" for="api_ip">API IP Override</label>
+          <input class="homey-form-input" type="text" id="api_ip" placeholder="optional" />
+        </div>
         <button class="homey-button-primary" type="submit">Save</button>
       </form>
     </fieldset>

--- a/settings/index.js
+++ b/settings/index.js
@@ -3,6 +3,7 @@ async function onHomeyReady(Homey) {
 
   const emailField = document.getElementById('email');
   const passwordField = document.getElementById('password');
+  const ipField = document.getElementById('api_ip');
   const form = document.getElementById('credentials-form');
 
   try {
@@ -19,11 +20,19 @@ async function onHomeyReady(Homey) {
     // Ignore missing password setting
   }
 
+  try {
+    const apiIp = await Homey.get('api_ip');
+    if (apiIp) ipField.value = apiIp;
+  } catch (err) {
+    // Ignore missing api_ip setting
+  }
+
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     try {
       await Homey.set('email', emailField.value);
       await Homey.set('password', passwordField.value);
+      await Homey.set('api_ip', ipField.value);
       Homey.alert('Settings saved');
     } catch (err) {
       Homey.alert(err.message || err.toString());


### PR DESCRIPTION
## Summary
- add optional API IP override field in settings
- propagate IP override through driver and device
- support direct-IP connections in wifipool library

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895cc7faab48330b7035dafc5e6dfd6