### PR TITLE
Remove unsupported getDevice API usage

### DIFF
--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -48,13 +48,6 @@ async function login(email, password, ip) {
     userDomain = '';
   }
 
-  // Na een succesvolle login: haal alle beschikbare sensorgegevens op
-  try {
-    await logAvailableSensors(userDomain, authCookies, ip);
-  } catch (err) {
-    console.log('WiFi Pool API sensor retrieval failed', err.message || err);
-  }
-
   return { cookies: authCookies, domain: userDomain };
 }
 
@@ -96,67 +89,6 @@ async function getStats(domain, io, cookies = authCookies, ip) {
   return json;
 }
 
-// Vraag lijst met beschikbare devices op
-async function getDevices(domain = userDomain, cookies = authCookies, ip) {
-  const path = '/native_mobile/harmopool/getDevice';
-
-  console.log('WiFi Pool API devices request', { path, domain });
-
-  const body = domain ? { domain } : {};
-  console.log('WiFi Pool API devices payload', body);
-
-  const response = await apiFetch(path, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Cookie': cookies
-    },
-    body: JSON.stringify(body),
-  }, ip);
-
-  console.log('WiFi Pool API devices response', { status: response.status });
-
-  if (!response.ok) {
-    throw new Error(`Device request failed: ${response.status}`);
-  }
-
-  const json = await response.json();
-  console.log('WiFi Pool API devices data', json);
-  return json;
-}
-
-// Probeer alle sensorgegevens voor de gebruiker op te halen en loggen
-async function logAvailableSensors(domain, cookies, ip) {
-  try {
-    const devicesData = await getDevices(domain, cookies, ip);
-    const devices = Array.isArray(devicesData)
-      ? devicesData
-      : devicesData?.devices;
-
-    if (Array.isArray(devices)) {
-      for (const device of devices) {
-        const rawIo = device?.io_list || device?.io;
-        const ioArray = Array.isArray(rawIo)
-          ? rawIo
-          : rawIo
-            ? [rawIo]
-            : [];
-
-        for (const io of ioArray) {
-          if (!io) continue;
-          try {
-            const stats = await getStats(domain, io, cookies, ip);
-            console.log('WiFi Pool API sensor data', { io, stats });
-          } catch (err) {
-            console.log('WiFi Pool API sensor error', { io, error: err.message || err });
-          }
-        }
-      }
-    }
-  } catch (err) {
-    console.log('WiFi Pool API devices retrieval failed', err.message || err);
-  }
-}
 
 // Extract laatste waarde voor een key uit "analog" sensor data
 function extractAnalog(data, key) {
@@ -188,7 +120,6 @@ module.exports = {
   getCookies,
   getDomain,
   getStats,
-  getDevices,
   extractAnalog,
   extractSwitch
 };


### PR DESCRIPTION
## Summary
- Drop calls to nonexistent `/harmopool/getDevice` endpoint
- Simplify WiFi Pool login to just return cookies and domain
- Keep sensor retrieval limited to `/harmopool/getStats`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895d21d35dc8330a050334823f8ac6f