### PR TITLE
Log WiFi Pool sensors after API login

### DIFF
--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -48,6 +48,11 @@ async function login(email, password, ip) {
     userDomain = '';
   }
 
+  // Na succesvolle login probeer alle beschikbare informatie op te vragen
+  if (userDomain) {
+    await logAllInfo(userDomain, authCookies, ip);
+  }
+
   return { cookies: authCookies, domain: userDomain };
 }
 
@@ -89,6 +94,62 @@ async function getStats(domain, io, cookies = authCookies, ip) {
   return json;
 }
 
+// Haal beschikbare sensoren voor een domein op
+async function getSensors(domain, cookies = authCookies, ip) {
+  const path = '/native_mobile/harmopool/getSensors';
+  const data = { domain };
+
+  console.log('WiFi Pool API sensors request', { path, domain });
+  console.log('WiFi Pool API sensors payload', data);
+
+  const response = await apiFetch(path, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Cookie': cookies
+    },
+    body: JSON.stringify(data),
+  }, ip);
+
+  console.log('WiFi Pool API sensors response', { status: response.status });
+
+  if (!response.ok) {
+    throw new Error(`Sensors request failed: ${response.status}`);
+  }
+
+  const json = await response.json();
+  console.log('WiFi Pool API sensors data', json);
+  return json;
+}
+
+// Log alle beschikbare sensoren en hun data
+async function logAllInfo(domain, cookies = authCookies, ip) {
+  try {
+    const sensorsResponse = await getSensors(domain, cookies, ip);
+    const sensors = Array.isArray(sensorsResponse)
+      ? sensorsResponse
+      : Array.isArray(sensorsResponse?.sensors)
+        ? sensorsResponse.sensors
+        : [];
+
+    console.log('WiFi Pool API available sensors', sensors);
+
+    for (const sensor of sensors) {
+      const io = sensor?.io;
+      if (io) {
+        try {
+          const stats = await getStats(domain, io, cookies, ip);
+          console.log('WiFi Pool API sensor stats', { io, stats });
+        } catch (err) {
+          console.log('WiFi Pool API sensor stats error', { io, error: err.message || err });
+        }
+      }
+    }
+  } catch (err) {
+    console.log('WiFi Pool API sensors fetch error', err.message || err);
+  }
+}
+
 
 // Extract laatste waarde voor een key uit "analog" sensor data
 function extractAnalog(data, key) {
@@ -120,6 +181,7 @@ module.exports = {
   getCookies,
   getDomain,
   getStats,
+  getSensors,
   extractAnalog,
   extractSwitch
 };


### PR DESCRIPTION
## Summary
- fetch full sensor list from WiFi Pool API
- log stats for each sensor after successful login

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895d6e58dd08330aec88ac35dc96bb9