### PR TITLE
Log WiFi Pool sensors after API login

### DIFF
--- a/drivers/wifipool/driver.js
+++ b/drivers/wifipool/driver.js
@@ -6,6 +6,18 @@ const { login } = require('../../lib/wifipool.js');
 class WiFiPoolDriver extends Driver {
   async onInit() {
     this.log('WiFi Pool driver initialized');
+
+    const email = this.homey.settings.get('email');
+    const password = this.homey.settings.get('password');
+    const ip = this.homey.settings.get('api_ip');
+
+    if (email && password) {
+      try {
+        await login(email, password, ip);
+      } catch (err) {
+        this.error('Initial login failed', err.message || err);
+      }
+    }
   }
 
   async onPairListDevices() {

--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -1,5 +1,19 @@
 const fetch = require('node-fetch');
 const https = require('https');
+let Homey;
+try {
+  Homey = require('homey');
+} catch (err) {
+  Homey = null;
+}
+
+function log(...args) {
+  if (Homey && Homey.app && typeof Homey.app.log === 'function') {
+    Homey.app.log(...args);
+  } else {
+    console.log(...args);
+  }
+}
 
 const API_HOST = 'api.wifipool.eu';
 const API_BASE_URL = `https://${API_HOST}`;
@@ -22,7 +36,7 @@ async function login(email, password, ip) {
   const loginData = { email, namespace: 'default', password };
   const safeLoginData = { ...loginData, password: '***' };
 
-  console.log('WiFi Pool API login request', { path, body: safeLoginData });
+  log('WiFi Pool API login request', { path, body: safeLoginData });
 
   const response = await apiFetch(path, {
     method: 'POST',
@@ -30,7 +44,7 @@ async function login(email, password, ip) {
     body: JSON.stringify(loginData),
   }, ip);
 
-  console.log('WiFi Pool API login response', { status: response.status });
+  log('WiFi Pool API login response', { status: response.status });
 
   if (!response.ok) {
     throw new Error(`Login failed: ${response.status}`);
@@ -41,11 +55,16 @@ async function login(email, password, ip) {
   // Probeer het domein uit de login response op te slaan
   try {
     const body = await response.json();
-    console.log('WiFi Pool API login data', body);
+    log('WiFi Pool API login data', body);
     userDomain = body?.user?.domain || '';
   } catch (err) {
     // Als het parsen mislukt, is het niet fataal
     userDomain = '';
+  }
+
+  // Na succesvolle login probeer alle beschikbare informatie op te vragen
+  if (userDomain) {
+    await logAllInfo(userDomain, authCookies, ip);
   }
 
   return { cookies: authCookies, domain: userDomain };
@@ -66,8 +85,8 @@ async function getStats(domain, io, cookies = authCookies, ip) {
   const path = '/native_mobile/harmopool/getStats';
   const data = { after: 0, domain, io };
 
-  console.log('WiFi Pool API stats request', { path, domain, io });
-  console.log('WiFi Pool API stats payload', data);
+  log('WiFi Pool API stats request', { path, domain, io });
+  log('WiFi Pool API stats payload', data);
 
   const response = await apiFetch(path, {
     method: 'POST',
@@ -78,15 +97,71 @@ async function getStats(domain, io, cookies = authCookies, ip) {
     body: JSON.stringify(data),
   }, ip);
 
-  console.log('WiFi Pool API stats response', { status: response.status });
+  log('WiFi Pool API stats response', { status: response.status });
 
   if (!response.ok) {
     throw new Error(`Data request failed: ${response.status}`);
   }
 
   const json = await response.json();
-  console.log('WiFi Pool API stats data', json);
+  log('WiFi Pool API stats data', json);
   return json;
+}
+
+// Haal beschikbare sensoren voor een domein op
+async function getSensors(domain, cookies = authCookies, ip) {
+  const path = '/native_mobile/harmopool/getSensors';
+  const data = { domain };
+
+  log('WiFi Pool API sensors request', { path, domain });
+  log('WiFi Pool API sensors payload', data);
+
+  const response = await apiFetch(path, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Cookie': cookies
+    },
+    body: JSON.stringify(data),
+  }, ip);
+
+  log('WiFi Pool API sensors response', { status: response.status });
+
+  if (!response.ok) {
+    throw new Error(`Sensors request failed: ${response.status}`);
+  }
+
+  const json = await response.json();
+  log('WiFi Pool API sensors data', json);
+  return json;
+}
+
+// Log alle beschikbare sensoren en hun data
+async function logAllInfo(domain, cookies = authCookies, ip) {
+  try {
+    const sensorsResponse = await getSensors(domain, cookies, ip);
+    const sensors = Array.isArray(sensorsResponse)
+      ? sensorsResponse
+      : Array.isArray(sensorsResponse?.sensors)
+        ? sensorsResponse.sensors
+        : [];
+
+    log('WiFi Pool API available sensors', sensors);
+
+    for (const sensor of sensors) {
+      const io = sensor?.io;
+      if (io) {
+        try {
+          const stats = await getStats(domain, io, cookies, ip);
+          log('WiFi Pool API sensor stats', { io, stats });
+        } catch (err) {
+          log('WiFi Pool API sensor stats error', { io, error: err.message || err });
+        }
+      }
+    }
+  } catch (err) {
+    log('WiFi Pool API sensors fetch error', err.message || err);
+  }
 }
 
 
@@ -120,6 +195,7 @@ module.exports = {
   getCookies,
   getDomain,
   getStats,
+  getSensors,
   extractAnalog,
   extractSwitch
 };


### PR DESCRIPTION
## Summary
- route WiFi Pool API logs through Homey's logger
- trigger initial API login when driver starts to print available sensors and stats

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895d6e58dd08330aec88ac35dc96bb9