### PR TITLE
Fix duplicate catch block in logAllInfo

### DIFF
--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -160,13 +160,10 @@ async function logAllInfo(domain, cookies = authCookies, ip) {
           const stats = await getStats(domain, io, cookies, ip);
 
           log('WiFi Pool API sensor stats', { io, stats });
-        } catch (err) {
-          log('WiFi Pool API sensor stats error', { io, error: err.message || err });
-
           console.log('WiFi Pool API sensor stats', { io, stats });
         } catch (err) {
+          log('WiFi Pool API sensor stats error', { io, error: err.message || err });
           console.log('WiFi Pool API sensor stats error', { io, error: err.message || err });
-
         }
       }
     }


### PR DESCRIPTION
## Summary
- handle sensor stats logging with a single catch block

## Testing
- `node -e "require('./lib/wifipool.js')"`


------
https://chatgpt.com/codex/tasks/task_e_6895de13895c8330aacd55b87d7f117f