### PR TITLE
Improve domain extraction for WiFi Pool login

### DIFF
--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -30,6 +30,15 @@ async function apiFetch(path, options = {}, ip) {
 let authCookies = '';
 let userDomain = '';
 
+function extractDomainFromLogin(body) {
+  return body?.user?.domain
+    || body?.user?.mobile_user_domain
+    || (Array.isArray(body?.user?.domains) && body.user.domains[0]?.domain)
+    || body?.domain
+    || (Array.isArray(body?.domains) && body.domains[0]?.domain)
+    || '';
+}
+
 // Login bij WiFi Pool API en sla cookies en relevante info op
 async function login(email, password, ip) {
   const path = '/native_mobile/users/login';
@@ -56,7 +65,10 @@ async function login(email, password, ip) {
   try {
     const body = await response.json();
     log('WiFi Pool API login data', body);
-    userDomain = body?.user?.domain || '';
+    userDomain = extractDomainFromLogin(body);
+    if (!userDomain) {
+      log('WiFi Pool API login: domain not found in response');
+    }
   } catch (err) {
     // Als het parsen mislukt, is het niet fataal
     userDomain = '';


### PR DESCRIPTION
## Summary
- add flexible `extractDomainFromLogin` helper
- log when no domain found in login response

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6895e208726483308cee279b04919ab5