### PR TITLE
Log sensors after API login

### DIFF
--- a/drivers/wifipool/driver.js
+++ b/drivers/wifipool/driver.js
@@ -13,7 +13,10 @@ class WiFiPoolDriver extends Driver {
 
     if (email && password) {
       try {
-        await login(email, password, ip);
+        const { sensors } = await login(email, password, ip);
+        if (Array.isArray(sensors) && sensors.length) {
+          this.log('Initial login sensors', sensors);
+        }
       } catch (err) {
         this.error('Initial login failed', err.message || err);
       }
@@ -32,7 +35,10 @@ class WiFiPoolDriver extends Driver {
     }
 
     try {
-      const { domain } = await login(email, password, ip);
+      const { domain, sensors } = await login(email, password, ip);
+      if (Array.isArray(sensors) && sensors.length) {
+        this.log('Pairing sensors', sensors);
+      }
       const devices = [
         {
           name: 'WiFi Pool Sensor',

--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -74,12 +74,13 @@ async function login(email, password, ip) {
     userDomain = '';
   }
 
+  let sensors = [];
   // Na succesvolle login probeer alle beschikbare informatie op te vragen
   if (userDomain) {
-    await logAllInfo(userDomain, authCookies, ip);
+    sensors = await logAllInfo(userDomain, authCookies, ip);
   }
 
-  return { cookies: authCookies, domain: userDomain };
+  return { cookies: authCookies, domain: userDomain, sensors };
 }
 
 // Haal de opgeslagen cookies op
@@ -154,6 +155,7 @@ async function getSensors(domain, cookies = authCookies, ip) {
 
 // Log alle beschikbare sensoren en hun data
 async function logAllInfo(domain, cookies = authCookies, ip) {
+  const result = [];
   try {
     const sensorsResponse = await getSensors(domain, cookies, ip);
     const sensors = Array.isArray(sensorsResponse)
@@ -173,18 +175,19 @@ async function logAllInfo(domain, cookies = authCookies, ip) {
 
           log('WiFi Pool API sensor stats', { io, stats });
           console.log('WiFi Pool API sensor stats', { io, stats });
+          result.push({ ...sensor, stats });
         } catch (err) {
           log('WiFi Pool API sensor stats error', { io, error: err.message || err });
           console.log('WiFi Pool API sensor stats error', { io, error: err.message || err });
+          result.push({ ...sensor, error: err.message || err });
         }
       }
     }
   } catch (err) {
-
     log('WiFi Pool API sensors fetch error', err.message || err);
     console.log('WiFi Pool API sensors fetch error', err.message || err);
-
   }
+  return result;
 }
 
 


### PR DESCRIPTION
## Summary
- collect and return sensor details during API login
- log discovered sensors when driver initializes or pairs devices

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895e476ff148330a4acd4b9af6f03e5