### PR TITLE
Log sensors after API login

### DIFF
--- a/drivers/wifipool/driver.js
+++ b/drivers/wifipool/driver.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const { Driver } = require('homey');
-const { login } = require('../../lib/wifipool.js');
+const { login, setLogger } = require('../../lib/wifipool.js');
 
 class WiFiPoolDriver extends Driver {
   async onInit() {
     this.log('WiFi Pool driver initialized');
+    setLogger(this.log.bind(this));
 
     const email = this.homey.settings.get('email');
     const password = this.homey.settings.get('password');
@@ -13,7 +14,8 @@ class WiFiPoolDriver extends Driver {
 
     if (email && password) {
       try {
-        await login(email, password, ip);
+        const { sensors } = await login(email, password, ip);
+        this.log('Initial login sensors', sensors);
       } catch (err) {
         this.error('Initial login failed', err.message || err);
       }
@@ -32,7 +34,8 @@ class WiFiPoolDriver extends Driver {
     }
 
     try {
-      const { domain } = await login(email, password, ip);
+      const { domain, sensors } = await login(email, password, ip);
+      this.log('Pairing sensors', sensors);
       const devices = [
         {
           name: 'WiFi Pool Sensor',

--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -7,9 +7,17 @@ try {
   Homey = null;
 }
 
+let logger = null;
+
+function setLogger(fn) {
+  logger = typeof fn === 'function' ? fn : null;
+}
+
 function log(...args) {
-  if (Homey && Homey.app && typeof Homey.app.log === 'function') {
-    Homey.app.log(...args);
+  if (logger) {
+    logger(...args);
+  } else if (Homey && typeof Homey.log === 'function') {
+    Homey.log(...args);
   } else {
     console.log(...args);
   }
@@ -74,12 +82,13 @@ async function login(email, password, ip) {
     userDomain = '';
   }
 
+  let sensors = [];
   // Na succesvolle login probeer alle beschikbare informatie op te vragen
   if (userDomain) {
-    await logAllInfo(userDomain, authCookies, ip);
+    sensors = await logAllInfo(userDomain, authCookies, ip);
   }
 
-  return { cookies: authCookies, domain: userDomain };
+  return { cookies: authCookies, domain: userDomain, sensors };
 }
 
 // Haal de opgeslagen cookies op
@@ -127,8 +136,6 @@ async function getSensors(domain, cookies = authCookies, ip) {
 
   log('WiFi Pool API sensors request', { path, domain });
   log('WiFi Pool API sensors payload', data);
-  console.log('WiFi Pool API sensors request', { path, domain });
-  console.log('WiFi Pool API sensors payload', data);
 
   const response = await apiFetch(path, {
     method: 'POST',
@@ -140,7 +147,6 @@ async function getSensors(domain, cookies = authCookies, ip) {
   }, ip);
 
   log('WiFi Pool API sensors response', { status: response.status });
-  console.log('WiFi Pool API sensors response', { status: response.status });
 
   if (!response.ok) {
     throw new Error(`Sensors request failed: ${response.status}`);
@@ -148,12 +154,12 @@ async function getSensors(domain, cookies = authCookies, ip) {
 
   const json = await response.json();
   log('WiFi Pool API sensors data', json);
-  console.log('WiFi Pool API sensors data', json);
   return json;
 }
 
 // Log alle beschikbare sensoren en hun data
 async function logAllInfo(domain, cookies = authCookies, ip) {
+  const result = [];
   try {
     const sensorsResponse = await getSensors(domain, cookies, ip);
     const sensors = Array.isArray(sensorsResponse)
@@ -163,7 +169,6 @@ async function logAllInfo(domain, cookies = authCookies, ip) {
         : [];
 
     log('WiFi Pool API available sensors', sensors);
-    console.log('WiFi Pool API available sensors', sensors);
 
     for (const sensor of sensors) {
       const io = sensor?.io;
@@ -172,19 +177,17 @@ async function logAllInfo(domain, cookies = authCookies, ip) {
           const stats = await getStats(domain, io, cookies, ip);
 
           log('WiFi Pool API sensor stats', { io, stats });
-          console.log('WiFi Pool API sensor stats', { io, stats });
+          result.push({ ...sensor, stats });
         } catch (err) {
           log('WiFi Pool API sensor stats error', { io, error: err.message || err });
-          console.log('WiFi Pool API sensor stats error', { io, error: err.message || err });
+          result.push({ ...sensor, error: err.message || err });
         }
       }
     }
   } catch (err) {
-
     log('WiFi Pool API sensors fetch error', err.message || err);
-    console.log('WiFi Pool API sensors fetch error', err.message || err);
-
   }
+  return result;
 }
 
 
@@ -219,6 +222,7 @@ module.exports = {
   getDomain,
   getStats,
   getSensors,
+  setLogger,
   extractAnalog,
   extractSwitch
 };


### PR DESCRIPTION
## Summary
- route WiFi Pool library logs through Homey driver so sensor queries show in the console
- log sensor data after login and during pairing for easier debugging

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895e476ff148330a4acd4b9af6f03e5