### PR TITLE
Fix pairing when no WiFi Pool devices are discovered

### DIFF
--- a/drivers/wifipool/driver.compose.json
+++ b/drivers/wifipool/driver.compose.json
@@ -14,7 +14,7 @@
     "cloud"
   ],
   "pair": [
-    { "id": "start" }
+    { "id": "list_devices" }
   ],
   "images": {
     "small": "/drivers/wifipool/assets/images/small.jpg",

--- a/drivers/wifipool/driver.js
+++ b/drivers/wifipool/driver.js
@@ -8,7 +8,12 @@ export default class WiFiPoolDriver extends Homey.Driver {
 
   // Built-in pairing flow ("pair": [{ "id": "list_devices" }])
   async onPairListDevices() {
-    return this._buildDeviceList();
+    try {
+      return await this._buildDeviceList();
+    } catch (err) {
+      this.error('[WiFiPool][Driver] onPairListDevices failed', err);
+      return [];
+    }
   }
 
   // Session-based pairing (e.g. custom pair/start.html)

--- a/drivers/wifipool/pair/list_devices.html
+++ b/drivers/wifipool/pair/list_devices.html
@@ -21,7 +21,7 @@
         const list = document.getElementById('device-list');
         try {
           const devices = await Homey.emit('list_devices');
-          if (!devices.length) {
+          if (!Array.isArray(devices) || devices.length === 0) {
             status.textContent = 'No devices found.';
             return;
           }


### PR DESCRIPTION
## Summary
- show a user-friendly "No devices found" message when pairing yields no WiFi Pool devices
- guard against pairing list failures so pairing doesn't hang
- use the custom list_devices pairing step

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e01450d3883309136ac40f2409562