### PR TITLE
Fix pairing hang by adding list_devices handler

### DIFF
--- a/drivers/wifipool/pair/start.js
+++ b/drivers/wifipool/pair/start.js
@@ -1,5 +1,17 @@
 export default class {
   onPair(socket) {
+    socket.on('list_devices', async (data, callback) => {
+      try {
+        const devices = [{
+          name: 'WiFi Pool',
+          data: { id: 'wifipool-1' }
+        }];
+        callback(null, devices);
+      } catch (err) {
+        callback(err);
+      }
+    });
+
     socket.on('add_device', async (data, callback) => {
       try {
         const device = {


### PR DESCRIPTION
## Summary
- implement `list_devices` handler in pairing start script so device discovery resolves

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e182735848330a541dbed68a6c00e