### PR TITLE
Add switch status tab to device tile

### DIFF
--- a/drivers/wifipool/driver.compose.json
+++ b/drivers/wifipool/driver.compose.json
@@ -35,6 +35,49 @@
     "large": "/drivers/wifipool/assets/images/large.jpg",
     "xlarge": "/drivers/wifipool/assets/images/xlarge.jpg"
   },
+  "mobile": {
+    "components": [
+      {
+        "id": "sensor",
+        "capabilities": [
+          "measure_temperature",
+          "measure_redox",
+          "measure_ph",
+          "alarm_flow",
+          "alarm_health"
+        ]
+      },
+      {
+        "id": "toggle",
+        "capabilities": [
+          "onoff_i0",
+          "onoff_i1",
+          "onoff_i2",
+          "onoff_i3",
+          "onoff_o0",
+          "onoff_o1",
+          "onoff_o2",
+          "onoff_o3"
+        ],
+        "options": {
+          "title": {
+            "en": "Detected switches",
+            "nl": "Gedetecteerde schakelaars",
+            "da": "Registrerede kontakter",
+            "de": "Erkannte Schalter",
+            "es": "Interruptores detectados",
+            "fr": "Interrupteurs détectés",
+            "it": "Interruttori rilevati",
+            "no": "Oppdagede brytere",
+            "sv": "Upptäckta brytare",
+            "pl": "Wykryte przełączniki",
+            "ru": "Обнаруженные переключатели",
+            "ko": "감지된 스위치"
+          }
+        }
+      }
+    ]
+  },
   "platforms": [
     "local",
     "cloud"


### PR DESCRIPTION
## Summary
- add dynamic switch capability management on the device to mirror detected IOs
- update the flow polling loop to keep switch capabilities in sync with the hardware state
- expose a new mobile view tab that lists the detected switch toggles on the device tile

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d52321f05c8330a5debe95768f55b3