### PR TITLE
Refine switch control and status presentation

### DIFF
--- a/app.json
+++ b/app.json
@@ -1066,8 +1066,8 @@
         "ko": "릴레이 o0"
       },
       "getable": true,
-      "setable": true,
-      "uiComponent": "toggle"
+      "setable": false,
+      "uiComponent": "sensor"
     },
     "onoff_o1": {
       "type": "boolean",
@@ -1086,8 +1086,8 @@
         "ko": "Relay o1"
       },
       "getable": true,
-      "setable": true,
-      "uiComponent": "toggle"
+      "setable": false,
+      "uiComponent": "sensor"
     },
     "onoff_o2": {
       "type": "boolean",
@@ -1106,8 +1106,8 @@
         "ko": "릴레이 o2"
       },
       "getable": true,
-      "setable": true,
-      "uiComponent": "toggle"
+      "setable": false,
+      "uiComponent": "sensor"
     },
     "onoff_o3": {
       "type": "boolean",
@@ -1126,8 +1126,8 @@
         "ko": "릴레이 o3"
       },
       "getable": true,
-      "setable": true,
-      "uiComponent": "toggle"
+      "setable": false,
+      "uiComponent": "sensor"
     }
   }
 }

--- a/drivers/wifipool/device.js
+++ b/drivers/wifipool/device.js
@@ -126,8 +126,8 @@ export default class WiFiPoolDevice extends Homey.Device {
 
     for (const [cap, handler] of Object.entries(this._switchListenerByCap)) {
       const io = this._switchIoByCapability?.[cap] || '';
-      const isOutput = /\.o\d+$/i.test(io);
-      const keepListener = desiredCaps.has(cap) && this.hasCapability(cap) && isOutput;
+      const isInput = /\.i\d+$/i.test(io);
+      const keepListener = desiredCaps.has(cap) && this.hasCapability(cap) && isInput;
       if (keepListener) continue;
 
       if (typeof this.unregisterCapabilityListener === 'function') {
@@ -144,22 +144,22 @@ export default class WiFiPoolDevice extends Homey.Device {
       if (!this.hasCapability(cap)) continue;
 
       const io = this._switchIoByCapability?.[cap] || '';
-      const isOutput = /\.o\d+$/i.test(io);
+      const isInput = /\.i\d+$/i.test(io);
 
       try {
         if (typeof this.setCapabilityOptions === 'function') {
           const existing = typeof this.getCapabilityOptions === 'function'
             ? this.getCapabilityOptions(cap) || {}
             : {};
-          if (existing.setable !== isOutput) {
-            await this.setCapabilityOptions(cap, { ...existing, setable: isOutput });
+          if (existing.setable !== isInput) {
+            await this.setCapabilityOptions(cap, { ...existing, setable: isInput });
           }
         }
       } catch (err) {
         this.error(`[WiFiPool][Device] failed to set capability options ${cap}:`, err?.message || err);
       }
 
-      if (!isOutput) continue;
+      if (!isInput) continue;
 
       if (this._switchListenerByCap[cap]) continue;
 
@@ -195,7 +195,7 @@ export default class WiFiPoolDevice extends Homey.Device {
       throw new Error('Switch not mapped');
     }
 
-    if (!/\.o\d+$/i.test(io)) {
+    if (!/\.i\d+$/i.test(io)) {
       this.error('[WiFiPool][Device] capability command for read-only sensor', cap, io);
       throw new Error('Switch is read-only');
     }
@@ -216,7 +216,7 @@ export default class WiFiPoolDevice extends Homey.Device {
     const domain = store.domain;
     if (!domain) throw new Error('Missing domain in device store');
 
-    if (!/\.o\d+$/i.test(io || '')) {
+    if (!/\.i\d+$/i.test(io || '')) {
       throw new Error('Cannot control sensor IO');
     }
 

--- a/drivers/wifipool/driver.compose.json
+++ b/drivers/wifipool/driver.compose.json
@@ -48,12 +48,33 @@
         ]
       },
       {
-        "id": "toggle",
+        "id": "switch-controls",
         "capabilities": [
           "onoff_i0",
           "onoff_i1",
           "onoff_i2",
-          "onoff_i3",
+          "onoff_i3"
+        ],
+        "options": {
+          "title": {
+            "en": "Switch controls",
+            "nl": "Switch controls",
+            "da": "Switch controls",
+            "de": "Switch controls",
+            "es": "Switch controls",
+            "fr": "Switch controls",
+            "it": "Switch controls",
+            "no": "Switch controls",
+            "sv": "Switch controls",
+            "pl": "Switch controls",
+            "ru": "Switch controls",
+            "ko": "Switch controls"
+          }
+        }
+      },
+      {
+        "id": "switch-status",
+        "capabilities": [
           "onoff_o0",
           "onoff_o1",
           "onoff_o2",
@@ -61,18 +82,18 @@
         ],
         "options": {
           "title": {
-            "en": "Detected switches",
-            "nl": "Gedetecteerde schakelaars",
-            "da": "Registrerede kontakter",
-            "de": "Erkannte Schalter",
-            "es": "Interruptores detectados",
-            "fr": "Interrupteurs détectés",
-            "it": "Interruttori rilevati",
-            "no": "Oppdagede brytere",
-            "sv": "Upptäckta brytare",
-            "pl": "Wykryte przełączniki",
-            "ru": "Обнаруженные переключатели",
-            "ko": "감지된 스위치"
+            "en": "Switch status",
+            "nl": "Switch status",
+            "da": "Switch status",
+            "de": "Switch status",
+            "es": "Switch status",
+            "fr": "Switch status",
+            "it": "Switch status",
+            "no": "Switch status",
+            "sv": "Switch status",
+            "pl": "Switch status",
+            "ru": "Switch status",
+            "ko": "Switch status"
           }
         }
       }


### PR DESCRIPTION
## Summary
- split the mobile layout so inputs and outputs appear on separate tabs
- expose onoff_o capabilities as read-only status sensors
- listen for commands on onoff_i capabilities only and ignore status updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d52cec52e48330940050867cb76471