### PR TITLE
Fix default writable detection for WiFiPool output switches

### DIFF
--- a/drivers/wifipool/device.js
+++ b/drivers/wifipool/device.js
@@ -74,7 +74,7 @@ export default class WiFiPoolDevice extends Homey.Device {
       mapping[io] = capId;
       reverse[capId] = io;
       const prev = this._switchWritableIo?.[io];
-      writable[io] = prev == null ? (/\.i\d+$/i.test(io)) : !!prev;
+      writable[io] = prev == null ? (/\.o\d+$/i.test(io)) : !!prev;
     }
 
     this._switchCapabilityByIo = mapping;


### PR DESCRIPTION
## Summary
- default new switch IO mappings to writable when they target output channels so capability listeners register immediately

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5335b773c8330baa75c17f7e261c3