### PR TITLE
Prevent outputs from being treated as read-only sensors

### DIFF
--- a/drivers/wifipool/device.js
+++ b/drivers/wifipool/device.js
@@ -557,12 +557,13 @@ export default class WiFiPoolDevice extends Homey.Device {
         const sample = arr[arr.length - 1];
         const ts = Date.parse(sample?.device_sensor_time) || 0;
         if (!this._switchWritableIo) this._switchWritableIo = Object.create(null);
+        const isOutput = /\.o\d+$/i.test(io);
         const hasStateData = sample && sample.device_state_data && typeof sample.device_state_data === 'object' && Object.keys(sample.device_state_data).length > 0;
         const hasSensorData = sample && sample.device_sensor_data && typeof sample.device_sensor_data === 'object' && Object.keys(sample.device_sensor_data).length > 0;
         if (hasStateData && this._switchWritableIo[io] !== true) {
           this._switchWritableIo[io] = true;
           writableChanged = true;
-        } else if (!hasStateData && hasSensorData && this._switchWritableIo[io] !== false) {
+        } else if (!isOutput && !hasStateData && hasSensorData && this._switchWritableIo[io] !== false) {
           this._switchWritableIo[io] = false;
           writableChanged = true;
         }


### PR DESCRIPTION
## Summary
- keep output IOs marked as writable when parsing flow samples that contain only sensor data
- avoid unregistering the on/off capability listeners for actual relays because of missing state data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5397a96208330af0b0c9c482dfe3a