### PR TITLE
Avoid calling setManualIO on sensor inputs

### DIFF
--- a/drivers/wifipool/device.js
+++ b/drivers/wifipool/device.js
@@ -243,13 +243,15 @@ export default class WiFiPoolDevice extends Homey.Device {
     const powerIo = pair?.power || (/\.i\d+$/i.test(io) ? io : null);
 
     const commands = [];
+    const isOutputIo = ioId => /\.o\d+$/i.test(ioId || '');
+
     if (bool) {
       if (manualIo) commands.push({ io: manualIo, target: true, options: {} });
-      if (powerIo && powerIo !== manualIo) {
+      if (powerIo && powerIo !== manualIo && isOutputIo(powerIo)) {
         commands.push({ io: powerIo, target: true, options: { skipWritableCheck: true, markWritable: false } });
       }
     } else {
-      if (powerIo) {
+      if (powerIo && isOutputIo(powerIo)) {
         commands.push({ io: powerIo, target: false, options: { skipWritableCheck: manualIo !== powerIo, markWritable: false } });
       }
       if (manualIo && manualIo !== powerIo) {


### PR DESCRIPTION
## Summary
- avoid issuing setManualIO requests for paired power IOs that are sensors
- ensure switch commands only target actual outputs, preventing HTTP 403 errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d54a5606988330b0863edf0e0c575f