### PR TITLE
Convert WiFiPool app to CommonJS modules

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,4 +1,4 @@
-// api.js — Homey SDK v3 (ESM)
+// api.js — Homey SDK v3 (CommonJS)
 // Endpoints (must match app.json "api" section):
 //   - testApi      (POST /test)
 //   - discoverIos  (POST /discover)
@@ -12,9 +12,9 @@
   { "id": "autoSetup",   "path": "/autosetup", "method": "POST", "public": false }
 ]
 */
-// package.json: { "type": "module", "dependencies": { "node-fetch": "^3.3.2" } }
+// package.json: { "dependencies": { "node-fetch": "^3.3.2" } }
 
-import fetch from 'node-fetch';
+const fetch = require('./lib/fetch');
 
 const BASE = 'https://api.wifipool.eu/native_mobile';
 let REQ = 0;
@@ -263,7 +263,7 @@ function detectFromStats(arr) {
 }
 
 // ----- Auto-setup core flow -----
-export async function autoSetupCore(homey) {
+async function autoSetupCore(homey) {
   // 1) login
   const { cookie, user } = await login(homey);
   const loginUserId = user?.mobile_user_id;
@@ -335,7 +335,7 @@ export async function autoSetupCore(homey) {
 }
 
 // ----- Exported API (default export required by ManagerApi) -----
-export default {
+const apiHandlers = {
   // Quick connectivity check
   async testApi({ homey }) {
     const { cookie, user } = await login(homey);
@@ -360,4 +360,9 @@ export default {
     const result = await autoSetupCore(homey);
     return { ok: true, ...result };
   },
+};
+
+module.exports = {
+  ...apiHandlers,
+  autoSetupCore,
 };

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
-import Homey from 'homey';
-import apiHandlers from './api.js';
+const Homey = require('homey');
+const apiHandlers = require('./api');
 
 const API_DEFINITIONS = [
   { id: 'testApi', method: 'POST', path: '/test' },
@@ -7,7 +7,7 @@ const API_DEFINITIONS = [
   { id: 'autoSetup', method: 'POST', path: '/autosetup' },
 ];
 
-export default class WiFiPoolApp extends Homey.App {
+class WiFiPoolApp extends Homey.App {
   async onInit() {
     this.log('[WiFiPool][App] init');
 
@@ -126,3 +126,5 @@ export default class WiFiPoolApp extends Homey.App {
     }
   }
 }
+
+module.exports = WiFiPoolApp;

--- a/drivers/wifipool/device.js
+++ b/drivers/wifipool/device.js
@@ -1,12 +1,12 @@
-// drivers/wifipool/device.js — Homey SDK v3 (ESM)
-import Homey from 'homey';
-import fetch from 'node-fetch';
+// drivers/wifipool/device.js — Homey SDK v3 (CommonJS)
+const Homey = require('homey');
+const fetch = require('../../lib/fetch');
 
 const BASE = 'https://api.wifipool.eu/native_mobile';
 const STALE_MS = 5 * 60 * 1000;          // 5 minutes for pH/ORP/Temp
 const FLOW_ANALOG_THRESHOLD = 0.5;       // abs(analog) >= threshold => flow=true
 
-export default class WiFiPoolDevice extends Homey.Device {
+class WiFiPoolDevice extends Homey.Device {
   async onInit() {
     this.log('[WiFiPool][Device] init:', this.getName());
 
@@ -352,3 +352,5 @@ export default class WiFiPoolDevice extends Homey.Device {
     this.log('[WiFiPool][Device] flow: no conclusive evidence this round');
   }
 }
+
+module.exports = WiFiPoolDevice;

--- a/drivers/wifipool/driver.js
+++ b/drivers/wifipool/driver.js
@@ -1,6 +1,6 @@
-// drivers/wifipool/driver.js — Homey SDK v3 (ESM)
-import Homey from 'homey';
-import fetch from 'node-fetch';
+// drivers/wifipool/driver.js — Homey SDK v3 (CommonJS)
+const Homey = require('homey');
+const fetch = require('../../lib/fetch');
 
 const BASE = 'https://api.wifipool.eu/native_mobile';
 let REQ = 0;
@@ -294,7 +294,7 @@ async function autoDiscover(driver, { email, password }) {
 }
 
 // ---------- Driver ----------
-export default class WiFiPoolDriver extends Homey.Driver {
+class WiFiPoolDriver extends Homey.Driver {
   async onInit() {
     this.log('[WiFiPool][Driver] init');
   }
@@ -340,3 +340,5 @@ export default class WiFiPoolDriver extends Homey.Driver {
     return [];
   }
 }
+
+module.exports = WiFiPoolDriver;

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,0 +1,17 @@
+let fetchFn = typeof globalThis.fetch === 'function'
+  ? globalThis.fetch.bind(globalThis)
+  : null;
+let fetchModulePromise = null;
+
+module.exports = (...args) => {
+  if (fetchFn) {
+    return fetchFn(...args);
+  }
+  if (!fetchModulePromise) {
+    fetchModulePromise = import('node-fetch').then(mod => {
+      fetchFn = mod.default || mod;
+      return fetchFn;
+    });
+  }
+  return fetchModulePromise.then(fn => fn(...args));
+};

--- a/lib/wifipool.js
+++ b/lib/wifipool.js
@@ -1,10 +1,10 @@
-import fetch from 'node-fetch';
+const fetch = require('./fetch');
 
 
 const LOGIN_URL = 'https://api.wifipool.eu/native_mobile/users/login';
 const STATS_URL = 'https://api.wifipool.eu/native_mobile/harmopool/getStats';
 
-export class WiFiPoolClient {
+class WiFiPoolClient {
   constructor(app) {
     this.app = app;
 
@@ -79,3 +79,7 @@ export class WiFiPoolClient {
     return json;
   }
 }
+
+module.exports = {
+  WiFiPoolClient,
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "com.wifipool",
   "version": "1.2.0",
-  "type": "module",
   "license": "MIT",
   "dependencies": {
     "node-fetch": "^3.3.2"

--- a/test.js
+++ b/test.js
@@ -2,13 +2,10 @@
 // Minimal sanity checks for the Homey WiFiPool app.
 // Run with: npm test
 
-import { strict as assert } from 'node:assert';
-import fs from 'node:fs/promises';
-import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+const assert = require('assert').strict;
+const fs = require('fs/promises');
+const path = require('path');
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 const ROOT = __dirname;
 
 const errors = [];
@@ -27,10 +24,11 @@ async function readJson(relPath) {
 async function checkApiModule() {
   const apiPath = path.join(ROOT, 'api.js');
   try {
-    const mod = await import(pathToFileURL(apiPath).href);
-    assert.ok(mod && typeof mod.default === 'object', 'api.js default export should be an object');
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const handlers = require(apiPath);
+    assert.ok(handlers && typeof handlers === 'object', 'api.js should export an object');
     for (const fn of ['testApi', 'discoverIos', 'autoSetup']) {
-      assert.equal(typeof mod.default[fn], 'function', `api.js default export is missing function '${fn}'`);
+      assert.equal(typeof handlers[fn], 'function', `api.js export is missing function '${fn}'`);
     }
   } catch (e) {
     errors.push(`api.js import/shape failed: ${e.message}`);


### PR DESCRIPTION
## Summary
- remove ESM module configuration and convert app, API, driver, and device sources to CommonJS exports
- add a shared fetch helper that dynamically loads `node-fetch` when global fetch is unavailable
- update the smoke tests to use CommonJS requires so they continue working after the conversion

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d79214f9e083309fea5d7b837f39a2